### PR TITLE
msm8916-common: Get Magisk working pt. II

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -36,9 +36,9 @@ on early-init
     # Turn off backlight on blank
     write /sys/class/leds/lcd-backlight/trigger "backlight"
 
-    # Make magisk workable
+    # Get Magisk working
     symlink /system/bin /sbin
-    export PATH /sbin:/vendor/bin:/system/bin
+    export PATH /sbin:/system/bin
 
 on fs
     wait /dev/block/platform/soc.0/${ro.boot.bootdevice}

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -36,6 +36,10 @@ on early-init
     # Turn off backlight on blank
     write /sys/class/leds/lcd-backlight/trigger "backlight"
 
+    # Make magisk workable
+    symlink /system/bin /sbin
+    export PATH /sbin:/vendor/bin:/system/bin
+
 on fs
     wait /dev/block/platform/soc.0/${ro.boot.bootdevice}
     symlink /dev/block/platform/soc.0/${ro.boot.bootdevice} /dev/block/bootdevice


### PR DESCRIPTION
Defining both /vendor/bin and /system/bin causes severe confusion on system that prevents early-init stage to be done. This commit was done to leave /vendor/bin undefined thus prevent this confusion from happening.

Thanks to Tenshi2112 (@TeGaX) for showing me where this is defined so helping me understand what's wrong out of purpose.