### PR TITLE
msm8916-common: Enable support for rounded corners

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -132,8 +132,8 @@
     <!-- Should the pinner service pin the Home application? -->
     <bool name="config_pinnerHomeApp">true</bool>
 
-    <!-- Disable rounded corners on windows to improve graphics performance -->
-    <bool name="config_supportsRoundedCornersOnWindows">false</bool>
+    <!-- Enable support for rounded corners -->
+    <bool name="config_supportsRoundedCornersOnWindows">true</bool>
 
     <!-- The list of components which should be automatically disabled for a specific device. -->
     <string-array name="config_deviceDisabledComponents" translatable="false">

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -36,6 +36,10 @@ on early-init
     # Turn off backlight on blank
     write /sys/class/leds/lcd-backlight/trigger "backlight"
 
+    # Make magisk workable
+    symlink /system/bin /sbin
+    export PATH /sbin:/vendor/bin:/system/bin
+
 on fs
     wait /dev/block/platform/soc.0/${ro.boot.bootdevice}
     symlink /dev/block/platform/soc.0/${ro.boot.bootdevice} /dev/block/bootdevice


### PR DESCRIPTION
Enforcing 0dp corner (A.K.A. Disabling support for rounded corners) causes severe performance drop and instability when Android Go mode is turned on. We could turn Android Go mode off on device tree instead of enabling support for rounded corners on common tree but, as of Android 11, devices with *2 GB or less RAM* are *required* to use Android Go for whatever reason I don't know.

Thanks to HowToRush (@Simeonlps) for the idea and letting me see this.